### PR TITLE
expose job_id to route client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -86,13 +86,13 @@ Routific.prototype.route = function(problem, cb) {
   var routeEndpoint = problem.constructor.routingLongEndpoint;
   postRequest(self, routeEndpoint, problem.data, function(err, body) {
     if (err)
-      return cb(err)
+      return cb(err);
     self.jobPoll(body.job_id, function(err, jobResponse){
       if (err)
-        return cb(err)
+        return cb(err);
 
-      cb(undefined, jobResponse.output)
-    })
+      cb(undefined, jobResponse.output, body.job_id);
+    });
   });
 };
 


### PR DESCRIPTION
we need access to the `job_id` to be able to debug better when jobs fail. this PR expose the `job_id` to the caller 