### PR TITLE
Add 'remove' options for vehicles and points

### DIFF
--- a/lib/pdp.js
+++ b/lib/pdp.js
@@ -14,8 +14,16 @@ Pdp.prototype.addVisit = function(id, visit) {
   this.data.visits[id] = visit;
 }
 
+Pdp.prototype.removeVisit = function(id) {
+  delete this.data.visits[id];
+}
+
 Pdp.prototype.addVehicle = function(id, vehicle) {
   this.data.fleet[id] = vehicle;
+}
+
+Pdp.prototype.removeVehicle = function(id) {
+  delete this.data.fleet[id];
 }
 
 Pdp.prototype.addOption = function(id, option) {

--- a/lib/vrp.js
+++ b/lib/vrp.js
@@ -14,8 +14,16 @@ Vrp.prototype.addVisit = function(id, visit) {
   this.data.visits[id] = visit;
 }
 
+Vrp.prototype.removeVisit = function(id) {
+  delete this.data.visits[id];
+}
+
 Vrp.prototype.addVehicle = function(id, vehicle) {
   this.data.fleet[id] = vehicle;
+}
+
+Vrp.prototype.removeVehicle = function(id) {
+  delete this.data.fleet[id];
 }
 
 Vrp.prototype.addOption = function(id, option) {


### PR DESCRIPTION
This will allow removing vehicles and points without refreshing the page.