### PR TITLE
Fix global leaks 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -71,7 +71,7 @@ function Routific(configuration) {
 //   parsed body of the response.
 Routific.prototype.login = function(email, password, cb) {
   var self = this;
-  data = {email: email, password: password};
+  var data = {email: email, password: password};
   return new Promise((resolve, reject) => {
     postRequest(self, "/users/login", data, function(err, body) {
       if (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,7 +25,7 @@ function endpoint(client, endpointPath) {
 
 // Performs an http request
 function httpRequest(client, endpointPath, opts, cb) {
-  reqOpts = {
+  var reqOpts = {
     url: endpoint(client, endpointPath)
   }
   for(var k in opts){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routific",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Client to use Routific API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### What's in this PR
* Addresses concern of global leaks in https://github.com/routific/routific-node-client/issues/22 when using the `--check-leaks` flag when using the `mocha` test runner
* Fix was to declare `reqOpts` and `data` as local variables

<img width="571" alt="Screen Shot 2022-01-17 at 6 21 38 PM copy" src="https://user-images.githubusercontent.com/10181867/149860133-f1bbc20c-1f0f-4bc3-b4bc-55ffeb8d5521.png">

