### PR TITLE
Reject when the job fails to process

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,13 @@ var baseConfig = {
   version: 1
 }
 
+const JobStatus = {
+  ERROR: "error",
+  PROCESSING: "processing",
+  FINISHED: "finished"
+};
+Object.freeze(JobStatus);
+
 // Gets a configuration value from either the `configuration` or the default
 function getConfig(configuration, key){
   if(configuration && configuration.hasOwnProperty(key))
@@ -133,12 +140,22 @@ Routific.prototype.jobPoll = function(jobId, cb) {
         if (cb) cb(err)
         return reject(err);
       }
-      if (res.status != "finished"){
+
+      if (res.status == JobStatus.ERROR) {
+        const jobError = new Error(res.output);
+        const errorWithResponse = Object.assign(jobError, res);
+
+        if (cb) cb(errorWithResponse);
+        return reject(errorWithResponse);
+      }
+
+      if (res.status != JobStatus.FINISHED){
         setTimeout(function(){
           self.jobPoll(jobId, cb)
         }, self.pollDelay);
         return
       }
+
       if (cb) cb(undefined, res);
       resolve(res);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routific",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Client to use Routific API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently we continue polling even if the job request returns an error status (as raised in this issue: https://github.com/routific/routific-node-client/issues/23), now we'll reject the promise and allow the requesting app to handle the thrown error as appropriate.